### PR TITLE
Add Seasons and Episodes to Content Form

### DIFF
--- a/client/src/components/admin/content-form-dialog.tsx
+++ b/client/src/components/admin/content-form-dialog.tsx
@@ -14,7 +14,6 @@ import {
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Save, X, Database } from 'lucide-react';
 import type { Content, InsertContent, Subgenre } from '@shared/schema';
-import { useToast } from '@/hooks/use-toast';
 
 type Props = {
   open: boolean;
@@ -30,32 +29,30 @@ type Props = {
 type ContentFormData = {
   title: string;
   year: number;
-  rating: number;
-  criticsRating: number;
-  usersRating: number;
+  criticsRating: number | null;
+  usersRating: number | null;
   description: string;
   posterUrl: string;
   subgenres: string[];
   primarySubgenre?: string;
-  platforms: string[];
-  platformLinks: string[];
   type: 'movie' | 'series';
+  episodes?: number | null;
+  seasons?: number | null;
   active: boolean;
 };
 
 const initialFormData: ContentFormData = {
   title: '',
   year: new Date().getFullYear(),
-  rating: 0,
-  criticsRating: 0,
-  usersRating: 0,
+  criticsRating: null,
+  usersRating: null,
   description: '',
   posterUrl: '',
   subgenres: [],
   primarySubgenre: '',
-  platforms: [],
-  platformLinks: [],
   type: 'movie',
+  episodes: null,
+  seasons: null,
   active: false,
 };
 
@@ -69,7 +66,6 @@ export function ContentFormDialog({
   onCreate,
   onUpdate,
 }: Props) {
-  const { toast } = useToast();
   const [formData, setFormData] = useState<ContentFormData>(initialFormData);
 
   // map available subgenre slugs (used in checkboxes/select)
@@ -77,23 +73,17 @@ export function ContentFormDialog({
 
   useEffect(() => {
     if (editingContent) {
-      const platforms = editingContent.platforms || [];
-      const platformLinks = editingContent.platformLinks || [];
-      const normalizedLinks = [...platformLinks];
-      while (normalizedLinks.length < platforms.length) normalizedLinks.push('');
-
       setFormData({
         title: editingContent.title,
         year: editingContent.year,
-        rating: editingContent.rating,
-        criticsRating: editingContent.criticsRating ?? editingContent.rating,
-        usersRating: editingContent.usersRating ?? 0,
+        seasons: editingContent.seasons || null,
+        episodes: editingContent.episodes || null,
+        criticsRating: editingContent.criticsRating || null,
+        usersRating: editingContent.usersRating || null,
         description: editingContent.description,
         posterUrl: editingContent.posterUrl,
         subgenres: editingContent.subgenres || [],
         primarySubgenre: editingContent.subgenre || '',
-        platforms,
-        platformLinks: normalizedLinks,
         type: editingContent.type,
         active: Boolean(editingContent.active),
       });
@@ -163,6 +153,37 @@ export function ContentFormDialog({
               </Select>
             </div>
           </div>
+
+          {formData.type === 'series' && (
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label htmlFor="seasons" className="text-white">
+                  Seasons
+                </Label>
+                <Input
+                  id="seasons"
+                  value={formData.seasons}
+                  onChange={(e) =>
+                    setFormData((p) => ({ ...p, seasons: parseInt(e.target.value) || null }))
+                  }
+                  className="horror-bg border-gray-700 text-white"
+                />
+              </div>
+              <div>
+                <Label htmlFor="episodes" className="text-white">
+                  Episodes
+                </Label>
+                <Input
+                  id="episodes"
+                  value={formData.episodes}
+                  onChange={(e) =>
+                    setFormData((p) => ({ ...p, episodes: parseInt(e.target.value) || null }))
+                  }
+                  className="horror-bg border-gray-700 text-white"
+                />
+              </div>
+            </div>
+          )}
 
           <div className="grid grid-cols-3 gap-4">
             <div>

--- a/server/services/content-sync.ts
+++ b/server/services/content-sync.ts
@@ -173,7 +173,6 @@ class ContentSyncService {
             contentPlatforms.push({
               platformId: platform.id,
               webUrl: source.web_url,
-              format: source.format,
               seasons: source.seasons,
               episodes: source.episodes,
             });

--- a/server/services/new-to-streaming-sync.service.ts
+++ b/server/services/new-to-streaming-sync.service.ts
@@ -84,7 +84,6 @@ export class NewToStreamingSyncService {
           platformRows.push({
             platformId: platform.id,
             webUrl: src.web_url,
-            format: src.format,
             seasons: src.seasons,
             episodes: src.episodes,
           });

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -109,7 +109,6 @@ export const contentPlatforms = pgTable(
       .notNull()
       .references(() => platforms.id, { onDelete: 'cascade' }),
     webUrl: varchar('web_url', { length: 500 }),
-    format: varchar('format', { length: 20 }),
     seasons: integer('seasons'),
     episodes: integer('episodes'),
     createdAt: timestamp('created_at').defaultNow(),


### PR DESCRIPTION
This pull request updates the content form and related backend schema to better support TV series data and simplifies platform-related fields. The main changes include removing the `format` field from platform associations, and updating the form logic to handle these fields appropriately.

**Content Form and Data Model Updates:**

* Added `seasons` and `episodes` fields to the `ContentFormData` type and form UI, which are shown only for series content. This allows admins to specify the number of seasons and episodes for TV series.
* Changed `criticsRating` and `usersRating` fields in the form data to allow `null` values, improving flexibility for incomplete data.

**Platform Association Simplification:**

* Removed the `format` field from the `contentPlatforms` table schema and all related service logic, streamlining platform associations for content.

**Code Cleanup:**

* Removed unused imports and state related to platform links and toast notifications in `content-form-dialog.tsx`, as these are no longer required.