### PR TITLE
Calculate Average Rating on Admin Form Submit

### DIFF
--- a/client/src/components/admin/content-form-dialog.tsx
+++ b/client/src/components/admin/content-form-dialog.tsx
@@ -14,6 +14,7 @@ import {
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Save, X, Database } from 'lucide-react';
 import type { Content, InsertContent, Subgenre } from '@shared/schema';
+import { calculateAverageRating } from '@/lib/calculate-average-rating';
 
 type Props = {
   open: boolean;
@@ -98,6 +99,7 @@ export function ContentFormDialog({
       subgenre:
         formData.primarySubgenre || (formData.subgenres.length > 0 ? formData.subgenres[0] : ''),
       active: formData.active,
+      averageRating: calculateAverageRating(formData.criticsRating, formData.usersRating),
     };
 
     if (editingContent) {

--- a/client/src/lib/calculate-average-rating.ts
+++ b/client/src/lib/calculate-average-rating.ts
@@ -2,7 +2,7 @@ export function calculateAverageRating(
   criticScore: number | null | undefined,
   userRating: number | null | undefined
 ): number | null {
-  const normalizedCritic = typeof criticScore === 'number' ? criticScore / 10 : null;
+  const normalizedCritic = typeof criticScore === 'number' ? criticScore : null;
   const normalizedUser = typeof userRating === 'number' ? userRating : null;
 
   const scores = [normalizedCritic, normalizedUser].filter(

--- a/server/converters/watchmode-content.ts
+++ b/server/converters/watchmode-content.ts
@@ -1,7 +1,7 @@
 import { InsertContent } from '@shared/schema';
 import { WatchmodeRelease, WatchmodeTitle } from '@server/types/watchmode';
 import { getOptimalPosterUrl } from '@server/utils/watchmode-helpers';
-import { calculateAverageRating } from '@server/routes/utils/average-rating';
+import { calculateWatchmodeAverageRating } from '@server/routes/utils/watchmode-average-rating';
 import { tvdbAPI } from '@server/tvdb';
 
 /**
@@ -66,7 +66,7 @@ export async function convertWatchmodeTitleToContent(
   return {
     title: title.title,
     year: title.year,
-    averageRating: calculateAverageRating(title.critic_score, title.user_rating),
+    averageRating: calculateWatchmodeAverageRating(title.critic_score, title.user_rating),
     criticsRating: title.critic_score ? title.critic_score / 10 : null,
     usersRating: title.user_rating || null,
     description: title.plot_overview || `A ${type} from ${title.year}`,

--- a/server/routes/utils/watchmode-average-rating.ts
+++ b/server/routes/utils/watchmode-average-rating.ts
@@ -1,0 +1,17 @@
+export function calculateWatchmodeAverageRating(
+  criticScore: number | null | undefined,
+  userRating: number | null | undefined
+): number | null {
+  const normalizedCritic = typeof criticScore === 'number' ? criticScore / 10 : null;
+  const normalizedUser = typeof userRating === 'number' ? userRating : null;
+
+  const scores = [normalizedCritic, normalizedUser].filter(
+    (v): v is number => typeof v === 'number'
+  );
+
+  if (scores.length === 0) return null;
+
+  const average = scores.reduce((sum, v) => sum + v, 0) / scores.length;
+
+  return Math.round(average * 10) / 10; // rounded to 1 decimal place
+}


### PR DESCRIPTION
This pull request refactors how average ratings are calculated for content, separating the logic for admin form submissions and Watchmode API imports. The main change is the introduction of two distinct functions for average rating calculation, ensuring the correct normalization is applied depending on the data source. Additionally, the code is updated to use these functions in the appropriate places.

**Average rating calculation refactor:**

* Created a new function `calculateWatchmodeAverageRating` in `server/routes/utils/watchmode-average-rating.ts` to handle normalization for Watchmode API data, dividing critic scores by 10 and rounding the result to one decimal place.
* Updated `server/converters/watchmode-content.ts` to use `calculateWatchmodeAverageRating` instead of the previous `calculateAverageRating` for Watchmode imports, ensuring correct score normalization for imported content.

**Admin content form logic update:**

* Modified the admin content form in `client/src/components/admin/content-form-dialog.tsx` to use the client-side `calculateAverageRating` function, which does not divide critic scores by 10, reflecting the expected input scale for admin submissions.
* Adjusted the implementation of `calculateAverageRating` in `client/src/lib/calculate-average-rating.ts` (renamed from `server/routes/utils/average-rating.ts`) to remove critic score normalization, aligning with the form's input expectations.