### PR TITLE
Add API Prefix to Platform Endpoints

### DIFF
--- a/client/src/components/admin/content-platforms-dialog.tsx
+++ b/client/src/components/admin/content-platforms-dialog.tsx
@@ -57,10 +57,10 @@ export default function ContentPlatformsDialog({
 
   // All platforms for dropdown (public route)
   const { data: allPlatforms = [], isLoading: isLoadingPlatforms } = useQuery<PlatformListItem[]>({
-    queryKey: ['/platforms'],
+    queryKey: ['/api/platforms'],
     enabled: open,
     queryFn: async () => {
-      const res = await fetch('/platforms');
+      const res = await fetch('/api/platforms');
       if (!res.ok) throw new Error('Failed to load platforms');
       return res.json();
     },

--- a/server/routes/public/platforms.routes.ts
+++ b/server/routes/public/platforms.routes.ts
@@ -24,7 +24,7 @@ export function registerPlatformRoutes(app: Express) {
     }
   });
 
-  app.get('/platforms/:id', async (req: Request, res: Response) => {
+  app.get('/api/platforms/:id', async (req: Request, res: Response) => {
     try {
       const id = Number(req.params.id);
       if (Number.isNaN(id)) {
@@ -51,7 +51,7 @@ export function registerPlatformRoutes(app: Express) {
     }
   });
 
-  app.get('/platforms/by-key/:platformKey', async (req: Request, res: Response) => {
+  app.get('/api/platforms/by-key/:platformKey', async (req: Request, res: Response) => {
     try {
       const key = req.params.platformKey;
       if (!key) return res.status(400).json({ message: 'platformKey is required' });


### PR DESCRIPTION
This pull request updates the API route paths for platform-related endpoints to use the `/api/platforms` prefix. This resolves an issue where the platforms were not rendering in the Edit Platforms admin dialog.

API route updates:

* Updated the client-side query in `content-platforms-dialog.tsx` to fetch platform data from the `/api/platforms` endpoint instead of `/platforms`.
* Changed the server-side route for fetching a platform by ID from `/platforms/:id` to `/api/platforms/:id` in `platforms.routes.ts`.
* Changed the server-side route for fetching a platform by key from `/platforms/by-key/:platformKey` to `/api/platforms/by-key/:platformKey` in `platforms.routes.ts`.