### PR TITLE
Refactor use-toast Without Reducer

### DIFF
--- a/client/src/hooks/use-toast.ts
+++ b/client/src/hooks/use-toast.ts
@@ -1,9 +1,8 @@
 import * as React from 'react';
-
 import type { ToastActionElement, ToastProps } from '@/components/ui/toast';
 
 const TOAST_LIMIT = 1;
-const TOAST_REMOVE_DELAY = 1000000;
+const TOAST_REMOVE_DELAY = 2000;
 
 type ToasterToast = ToastProps & {
   id: string;
@@ -12,175 +11,115 @@ type ToasterToast = ToastProps & {
   action?: ToastActionElement;
 };
 
-const actionTypes = {
-  ADD_TOAST: 'ADD_TOAST',
-  UPDATE_TOAST: 'UPDATE_TOAST',
-  DISMISS_TOAST: 'DISMISS_TOAST',
-  REMOVE_TOAST: 'REMOVE_TOAST',
-} as const;
+type ToastInput = Omit<ToasterToast, 'id' | 'open' | 'onOpenChange'> & { duration?: number };
 
-let count = 0;
+type State = { toasts: ToasterToast[] };
 
-function genId() {
-  count = (count + 1) % Number.MAX_SAFE_INTEGER;
-  return count.toString();
+const listeners: Array<(s: State) => void> = [];
+const timers = new Map<string, ReturnType<typeof setTimeout>>();
+let state: State = { toasts: [] };
+let idCounter = 0;
+
+function nextId() {
+  idCounter = (idCounter + 1) % Number.MAX_SAFE_INTEGER;
+  return idCounter.toString();
 }
 
-type ActionType = typeof actionTypes;
+function emit() {
+  listeners.forEach((l) => l(state));
+}
 
-type Action =
-  | {
-      type: ActionType['ADD_TOAST'];
-      toast: ToasterToast;
-    }
-  | {
-      type: ActionType['UPDATE_TOAST'];
-      toast: Partial<ToasterToast>;
-    }
-  | {
-      type: ActionType['DISMISS_TOAST'];
-      toastId?: ToasterToast['id'];
-    }
-  | {
-      type: ActionType['REMOVE_TOAST'];
-      toastId?: ToasterToast['id'];
+function removeNow(id?: string) {
+  if (id == null) {
+    state = { toasts: [] };
+  } else {
+    state = {
+      toasts: state.toasts.filter((t) => t.id !== id),
     };
-
-interface State {
-  toasts: ToasterToast[];
+  }
+  emit();
 }
 
-const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
-
-const addToRemoveQueue = (toastId: string) => {
-  if (toastTimeouts.has(toastId)) {
-    return;
-  }
-
+function queueRemove(id: string) {
+  if (timers.has(id)) return;
   const timeout = setTimeout(() => {
-    toastTimeouts.delete(toastId);
-    dispatch({
-      type: 'REMOVE_TOAST',
-      toastId: toastId,
-    });
+    timers.delete(id);
+    removeNow(id);
   }, TOAST_REMOVE_DELAY);
-
-  toastTimeouts.set(toastId, timeout);
-};
-
-export const reducer = (state: State, action: Action): State => {
-  switch (action.type) {
-    case 'ADD_TOAST':
-      return {
-        ...state,
-        toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
-      };
-
-    case 'UPDATE_TOAST':
-      return {
-        ...state,
-        toasts: state.toasts.map((t) => (t.id === action.toast.id ? { ...t, ...action.toast } : t)),
-      };
-
-    case 'DISMISS_TOAST': {
-      const { toastId } = action;
-
-      // ! Side effects ! - This could be extracted into a dismissToast() action,
-      // but I'll keep it here for simplicity
-      if (toastId) {
-        addToRemoveQueue(toastId);
-      } else {
-        state.toasts.forEach((toast) => {
-          addToRemoveQueue(toast.id);
-        });
-      }
-
-      return {
-        ...state,
-        toasts: state.toasts.map((t) =>
-          t.id === toastId || toastId === undefined
-            ? {
-                ...t,
-                open: false,
-              }
-            : t
-        ),
-      };
-    }
-    case 'REMOVE_TOAST':
-      if (action.toastId === undefined) {
-        return {
-          ...state,
-          toasts: [],
-        };
-      }
-      return {
-        ...state,
-        toasts: state.toasts.filter((t) => t.id !== action.toastId),
-      };
-  }
-};
-
-const listeners: Array<(state: State) => void> = [];
-
-let memoryState: State = { toasts: [] };
-
-function dispatch(action: Action) {
-  memoryState = reducer(memoryState, action);
-  listeners.forEach((listener) => {
-    listener(memoryState);
-  });
+  timers.set(id, timeout);
 }
 
-type Toast = Omit<ToasterToast, 'id'>;
+function addToast(t: ToasterToast) {
+  state = {
+    toasts: [t, ...state.toasts].slice(0, TOAST_LIMIT),
+  };
+  emit();
+}
 
-function toast({ ...props }: Toast) {
-  const id = genId();
+function updateToast(id: string, patch: Partial<ToasterToast>) {
+  state = {
+    toasts: state.toasts.map((t) => (t.id === id ? { ...t, ...patch } : t)),
+  };
+  emit();
+}
 
-  const update = (props: ToasterToast) =>
-    dispatch({
-      type: 'UPDATE_TOAST',
-      toast: { ...props, id },
-    });
-  const dismiss = () => dispatch({ type: 'DISMISS_TOAST', toastId: id });
+function dismissOne(id: string) {
+  const existing = timers.get(id);
+  if (existing) {
+    clearTimeout(existing);
+    timers.delete(id);
+  }
+  state = {
+    toasts: state.toasts.map((t) => (t.id === id ? { ...t, open: false } : t)),
+  };
+  emit();
+  queueRemove(id);
+}
 
-  dispatch({
-    type: 'ADD_TOAST',
-    toast: {
-      ...props,
-      id,
-      open: true,
-      onOpenChange: (open) => {
-        if (!open) dismiss();
-      },
+function dismissAll() {
+  state.toasts.forEach((t) => dismissOne(t.id));
+}
+
+export function toast({ duration = 2000, ...props }: ToastInput) {
+  const id = nextId();
+
+  addToast({
+    ...props,
+    id,
+    open: true,
+    onOpenChange: (open) => {
+      if (!open) dismissOne(id);
     },
   });
 
+  if (duration > 0) {
+    const timeout = setTimeout(() => dismissOne(id), duration);
+    timers.set(id, timeout);
+  }
+
   return {
-    id: id,
-    dismiss,
-    update,
+    id,
+    dismiss: () => dismissOne(id),
+    update: (patch: Partial<ToasterToast>) => updateToast(id, patch),
   };
 }
 
-function useToast() {
-  const [state, setState] = React.useState<State>(memoryState);
+export function useToast() {
+  const [local, setLocal] = React.useState<State>(state);
 
   React.useEffect(() => {
-    listeners.push(setState);
+    listeners.push(setLocal);
     return () => {
-      const index = listeners.indexOf(setState);
-      if (index > -1) {
-        listeners.splice(index, 1);
-      }
+      const i = listeners.indexOf(setLocal);
+      if (i > -1) listeners.splice(i, 1);
     };
-  }, [state]);
+  }, []);
 
   return {
-    ...state,
+    ...local,
     toast,
-    dismiss: (toastId?: string) => dispatch({ type: 'DISMISS_TOAST', toastId }),
+    dismiss: (id?: string) => (id ? dismissOne(id) : dismissAll()),
   };
 }
 
-export { useToast, toast };
+export type { ToasterToast, ToastInput as Toast };


### PR DESCRIPTION
This pull request refactors the toast notification logic in `client/src/hooks/use-toast.ts` to simplify state management and improve reliability. The reducer-based approach is replaced with direct state mutation and event emission, and toast dismissal timing is corrected for better user experience.

**Toast logic and state management:**

* Replaced the reducer and action-based state management with direct state mutation, using a local `state` object and event listeners for updates.
* Removed global `dispatch` and `reducer` functions, simplifying toast addition, update, and removal to direct function calls.

**Toast timing and behavior:**

* Fixed the toast removal delay by changing `TOAST_REMOVE_DELAY` from `1000000` ms (over 16 minutes) to `2000` ms (2 seconds), ensuring toasts disappear in a reasonable timeframe.
* Added per-toast duration support and ensured that dismissing a toast triggers its removal after the specified delay.

**API and type improvements:**

* Introduced the `ToastInput` type for cleaner toast creation, and updated the exposed API for toast creation, updating, and dismissal.