### PR TITLE
Add Subgenres to Watchlist Content and Rename SubLite Type to SubgenreLite

### DIFF
--- a/client/src/components/movie-card.tsx
+++ b/client/src/components/movie-card.tsx
@@ -5,10 +5,10 @@ import { useWatchlist } from '@/hooks/use-watchlist';
 import type { ContentWithPlatforms } from '@shared/schema';
 import { getDisplaySubgenreName } from '@/lib/subgenres';
 
-type SubLite = { id: number; name: string; slug: string };
+type SubgenreLite = { id: number; name: string; slug: string };
 type MovieForCard = ContentWithPlatforms & {
-  subgenres?: SubLite[];
-  primarySubgenre?: SubLite | null;
+  subgenres?: SubgenreLite[];
+  primarySubgenre?: SubgenreLite | null;
   primarySubgenreId?: number | null;
 };
 

--- a/client/src/lib/subgenres.ts
+++ b/client/src/lib/subgenres.ts
@@ -1,22 +1,22 @@
-export type SubLite = { id: number; name: string; slug: string };
+export type SubgenreLite = { id: number; name: string; slug: string };
 
 export type HasSubgenres = {
-  subgenres?: SubLite[];
-  primarySubgenre?: SubLite | null;
+  subgenres?: SubgenreLite[];
+  primarySubgenre?: SubgenreLite | null;
   primarySubgenreId?: number | null;
 };
 
 /** Find a subgenre by slug from a list. */
 export function findSubgenreBySlug(
-  subs: SubLite[] | undefined,
+  subs: SubgenreLite[] | undefined,
   slug?: string | null
-): SubLite | undefined {
+): SubgenreLite | undefined {
   if (!subs || !slug || slug === 'all') return undefined;
   return subs.find((s) => s.slug === slug);
 }
 
 /** Resolve the primary subgenre, preferring the object, then ID lookup, then first item. */
-export function getPrimarySubgenre(item: HasSubgenres): SubLite | undefined {
+export function getPrimarySubgenre(item: HasSubgenres): SubgenreLite | undefined {
   if (item.primarySubgenre) return item.primarySubgenre ?? undefined;
   if (item.primarySubgenreId && item.subgenres?.length) {
     return item.subgenres.find((s) => s.id === item.primarySubgenreId);
@@ -38,7 +38,7 @@ export function getSubgenreNames(item: HasSubgenres): string[] {
 }
 
 /** Whether a given subgenre is the primary for an item. */
-export function isPrimarySubgenre(s: SubLite, item: HasSubgenres): boolean {
+export function isPrimarySubgenre(s: SubgenreLite, item: HasSubgenres): boolean {
   if (item.primarySubgenre?.id != null) return item.primarySubgenre.id === s.id;
   if (item.primarySubgenreId != null) return item.primarySubgenreId === s.id;
   // Fallback: if no primary defined, treat first in list as primary

--- a/client/src/pages/movie-detail.tsx
+++ b/client/src/pages/movie-detail.tsx
@@ -14,10 +14,10 @@ import { useSearch } from '@/contexts/SearchContext';
 import type { ContentWithPlatforms } from '@shared/schema';
 import { getPrimarySubgenre, getSubgenreNames } from '@/lib/subgenres';
 
-type SubLite = { id: number; name: string; slug: string };
+type SubgenreLite = { id: number; name: string; slug: string };
 type DetailMovie = ContentWithPlatforms & {
-  subgenres?: SubLite[];
-  primarySubgenre?: SubLite | null;
+  subgenres?: SubgenreLite[];
+  primarySubgenre?: SubgenreLite | null;
   primarySubgenreId?: number | null;
 };
 

--- a/client/src/pages/subgenres.tsx
+++ b/client/src/pages/subgenres.tsx
@@ -11,7 +11,7 @@ import Footer from '@/components/footer';
 import type { Subgenre } from '@shared/schema';
 
 // Shape returned by /api/content list (normalized + with names)
-type SubLite = { id: number; name: string; slug: string };
+type SubgenreLite = { id: number; name: string; slug: string };
 type MovieRow = {
   id: number;
   title: string;
@@ -21,8 +21,8 @@ type MovieRow = {
   criticsRating?: number | null;
   usersRating?: number | null;
   averageRating?: number | null;
-  subgenres?: SubLite[];
-  primarySubgenre?: SubLite | null;
+  subgenres?: SubgenreLite[];
+  primarySubgenre?: SubgenreLite | null;
 };
 
 interface SubgenreData {

--- a/server/storage/watchlist.ts
+++ b/server/storage/watchlist.ts
@@ -1,6 +1,6 @@
 import { db } from '@server/db';
-import { watchlist, content } from '@shared/schema';
-import { eq, and } from 'drizzle-orm';
+import { watchlist, content, contentSubgenres, subgenres } from '@shared/schema';
+import { eq, and, inArray } from 'drizzle-orm';
 import type { Content } from '@shared/schema';
 
 type WatchlistOptions = {
@@ -8,10 +8,17 @@ type WatchlistOptions = {
   includeInactive?: boolean;
 };
 
+type SubgenreLite = { id: number; name: string; slug: string };
+
+export type ContentWithSubgenres = Content & {
+  subgenres: SubgenreLite[];
+  primarySubgenre: SubgenreLite | null;
+};
+
 export async function getUserWatchlist(
   userId: number,
   options: WatchlistOptions = {}
-): Promise<Content[]> {
+): Promise<ContentWithSubgenres[]> {
   const conditions = [eq(watchlist.userId, userId)];
 
   if (!options.includeHidden) {
@@ -22,13 +29,53 @@ export async function getUserWatchlist(
     conditions.push(eq(content.active, true));
   }
 
+  // Base content for the user’s watchlist
   const results = await db
     .select({ content })
     .from(watchlist)
     .innerJoin(content, eq(watchlist.contentId, content.id))
     .where(and(...conditions));
 
-  return results.map((r) => r.content);
+  const rows = results.map((r) => r.content);
+  if (rows.length === 0) return [];
+
+  const contentIds = rows.map((c) => c.id);
+
+  // Batch-fetch all subgenres for these content IDs
+  const subRows = await db
+    .select({
+      contentId: contentSubgenres.contentId,
+      id: subgenres.id,
+      name: subgenres.name,
+      slug: subgenres.slug,
+    })
+    .from(contentSubgenres)
+    .innerJoin(subgenres, eq(contentSubgenres.subgenreId, subgenres.id))
+    .where(inArray(contentSubgenres.contentId, contentIds));
+
+  // Group subgenres by contentId
+  const subsByContentId = new Map<number, SubgenreLite[]>();
+  for (const r of subRows) {
+    const list = subsByContentId.get(r.contentId) ?? [];
+    list.push({ id: r.id, name: r.name, slug: r.slug });
+    subsByContentId.set(r.contentId, list);
+  }
+
+  // Merge and resolve primary subgenre (if you store `primarySubgenre` as a slug on content)
+  const withSubs: ContentWithSubgenres[] = rows.map((c) => {
+    const subs = subsByContentId.get(c.id) ?? [];
+    const primary = (c as any).primarySubgenre
+      ? (subs.find((s) => s.slug === (c as any).primarySubgenre) ?? null)
+      : null;
+
+    return {
+      ...c,
+      subgenres: subs,
+      primarySubgenre: primary,
+    };
+  });
+
+  return withSubs;
 }
 
 export async function addToWatchlist(userId: number, contentId: number): Promise<boolean> {


### PR DESCRIPTION
This pull request refactors and standardizes the handling of subgenre data across both the client and server codebases. The main change is renaming the type `SubLite` to `SubgenreLite` everywhere, and updating all related type definitions and usages to improve clarity and consistency. Additionally, the server-side watchlist and content queries are enhanced to always include subgenre and primary subgenre data, streamlining data access for the frontend.

**Type Standardization and Refactoring**

* Renamed the type `SubLite` to `SubgenreLite` throughout all client and server files, updating all references, type definitions, and function signatures for consistency.

**Server-Side Data Model Improvements**

* Updated all server-side content fetching functions (`getContentItemWithSubgenres`, `getContent`, etc.) to use the new `SubgenreLite` type for subgenre and primary subgenre fields, ensuring consistent structure for returned data.

**Enhanced Watchlist Functionality**

* Refactored the `getUserWatchlist` function to return a new type `ContentWithSubgenres`, which includes both subgenres and primary subgenre information for each item, using efficient batch queries and grouping logic.

**Expanded Content Query Features**

* Rewrote `getHiddenContent` and `getInactiveContent` to return extended content objects that include platforms, subgenres, and primary subgenre, matching the new data model and improving frontend integration.