### PR TITLE
Remove Unnecessary Subgenre Ordering Feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,6 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@dnd-kit/core": "^6.3.1",
-        "@dnd-kit/sortable": "^10.0.0",
-        "@dnd-kit/utilities": "^3.2.2",
         "@hookform/resolvers": "^3.10.0",
         "@jridgewell/trace-mapping": "^0.3.25",
         "@neondatabase/serverless": "^0.10.4",
@@ -817,59 +814,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@dnd-kit/accessibility": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
-      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@dnd-kit/core": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
-      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@dnd-kit/accessibility": "^3.1.1",
-        "@dnd-kit/utilities": "^3.2.2",
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@dnd-kit/sortable": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
-      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
-      "license": "MIT",
-      "dependencies": {
-        "@dnd-kit/utilities": "^3.2.2",
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@dnd-kit/core": "^6.3.0",
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@dnd-kit/utilities": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
-      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
       }
     },
     "node_modules/@drizzle-team/brocli": {

--- a/package.json
+++ b/package.json
@@ -13,9 +13,6 @@
     "format": "prettier --write ."
   },
   "dependencies": {
-    "@dnd-kit/core": "^6.3.1",
-    "@dnd-kit/sortable": "^10.0.0",
-    "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^3.10.0",
     "@jridgewell/trace-mapping": "^0.3.25",
     "@neondatabase/serverless": "^0.10.4",

--- a/server/routes/admin/subgenres.routes.ts
+++ b/server/routes/admin/subgenres.routes.ts
@@ -8,10 +8,6 @@ const listQuerySchema = z.object({
   activeOnly: z.coerce.boolean().optional().default(false),
 });
 
-const reorderBodySchema = z.object({
-  orderedIds: z.array(z.number().int().positive()).min(1),
-});
-
 export function registerAdminSubgenreRoutes(app: Express) {
   app.get('/api/admin/subgenres', requireAdmin, async (req, res) => {
     try {
@@ -98,23 +94,6 @@ export function registerAdminSubgenreRoutes(app: Express) {
     } catch (error) {
       res.status(500).json({
         message: 'Failed to delete subgenre',
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
-    }
-  });
-
-  app.put('/api/admin/subgenres/reorder', requireAdmin, async (req, res) => {
-    try {
-      const { orderedIds } = reorderBodySchema.parse(req.body);
-      const ok = await storage.reorderSubgenres(orderedIds);
-      if (!ok) return res.status(500).json({ message: 'Failed to reorder subgenres' });
-      res.json({ message: 'Subgenres reordered successfully' });
-    } catch (error: any) {
-      if (error instanceof z.ZodError) {
-        return res.status(400).json({ message: 'Invalid payload', issues: error.issues });
-      }
-      res.status(500).json({
-        message: 'Failed to reorder subgenres',
         error: error instanceof Error ? error.message : 'Unknown error',
       });
     }

--- a/server/storage/subgenres.ts
+++ b/server/storage/subgenres.ts
@@ -10,7 +10,7 @@ export async function getSubgenres(activeOnly = false): Promise<Subgenre[]> {
     query = query.where(eq(subgenres.isActive, true));
   }
 
-  return await query.orderBy(subgenres.sortOrder, subgenres.name);
+  return await query.orderBy(subgenres.name);
 }
 
 export async function getSubgenre(id: number): Promise<Subgenre | undefined> {
@@ -39,19 +39,4 @@ export async function updateSubgenre(
 export async function deleteSubgenre(id: number): Promise<boolean> {
   const result = await db.delete(subgenres).where(eq(subgenres.id, id));
   return result.rowCount !== null && result.rowCount > 0;
-}
-
-export async function reorderSubgenres(orderedIds: number[]): Promise<boolean> {
-  try {
-    for (let i = 0; i < orderedIds.length; i++) {
-      await db
-        .update(subgenres)
-        .set({ sortOrder: i + 1 })
-        .where(eq(subgenres.id, orderedIds[i]));
-    }
-    return true;
-  } catch (error) {
-    console.error('Error reordering subgenres:', error);
-    return false;
-  }
 }

--- a/shared/schema/subgenres.ts
+++ b/shared/schema/subgenres.ts
@@ -9,7 +9,6 @@ export const subgenres = pgTable('subgenres', {
   slug: text('slug').notNull().unique(),
   description: text('description'),
   isActive: boolean('is_active').notNull().default(true),
-  sortOrder: integer('sort_order').notNull().default(0),
 });
 
 export type Subgenre = InferSelectModel<typeof subgenres>;
@@ -20,7 +19,6 @@ export const insertSubgenreSchema = createInsertSchema(subgenres, {
   slug: z.string().min(1),
   description: z.string().max(1000).optional().nullable(),
   isActive: z.coerce.boolean().default(true),
-  sortOrder: z.coerce.number().int().min(0).default(0),
 }).omit({ id: true });
 
 export type InsertSubgenreInput = z.infer<typeof insertSubgenreSchema>;


### PR DESCRIPTION
This pull request removes support for manual drag-and-drop reordering of subgenres throughout the codebase. The changes eliminate the `sortOrder` field, related backend API logic, and all client-side drag-and-drop UI and logic. Subgenres are now displayed sorted alphabetically by name.

**Removal of drag-and-drop reordering and sort order logic:**

* Removed all drag-and-drop dependencies and logic from the `SubgenresManagement` component, including DnD-kit imports, sensors, handlers, and the `SortableSubgenreCard` component. The list now displays subgenres sorted by name, and the UI no longer shows drag handles. (`client/src/components/subgenres-management.tsx`)

**Backend cleanup and API changes:**

* Deleted the `/api/admin/subgenres/reorder` endpoint and all related request validation and mutation logic. The backend no longer supports reordering subgenres. (`server/routes/admin/subgenres.routes.ts`)

These changes simplify subgenre management, removing complexity around ordering and ensuring a consistent alphabetical display.