### PR TITLE
Remove Vercel Configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,0 @@
-{
-  "buildCommand": "vite build",
-  "outputDirectory": "dist",
-  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
-}


### PR DESCRIPTION
## Description
This application relies on a long-running Express server, which is not supported on Vercel. Since deployment will be handled on a platform that supports custom Node servers (e.g. Render, Railway, Fly.io), the Vercel configuration is no longer needed.

**Changes:**

Removed `vercel.json` and related Vercel config.