### PR TITLE
Refactor Google Analytics Event Action Names

### DIFF
--- a/client/src/components/movie-card.tsx
+++ b/client/src/components/movie-card.tsx
@@ -48,9 +48,9 @@ export default function MovieCard({
     const label = `${movie.id}:${movie.title}`;
 
     if (wasInWatchlist) {
-      trackEvent('Watchlist', 'Removed', label);
+      trackEvent('Watchlist', 'watchlist_removed', label);
     } else {
-      trackEvent('Watchlist', 'Added', label);
+      trackEvent('Watchlist', 'watchlist_added', label);
     }
 
     onWatchlistToggle?.();

--- a/client/src/pages/auth-page.tsx
+++ b/client/src/pages/auth-page.tsx
@@ -137,7 +137,7 @@ export default function AuthPage() {
                     <ForgotPasswordForm
                       siteKey={config.recaptchaSiteKey}
                       onBack={() => setShowForgotPassword(false)}
-                      onRequestSent={() => trackEvent('Auth', 'Requested Password Reset', 'Email')}
+                      onRequestSent={() => trackEvent('Auth', 'password_reset_requested', 'Email')}
                     />
                   ) : (
                     <>
@@ -164,14 +164,14 @@ export default function AuthPage() {
                           <LoginForm
                             siteKey={config.recaptchaSiteKey}
                             onShowForgot={() => setShowForgotPassword(true)}
-                            onSuccess={() => trackEvent('User', 'Logged In', 'Email')}
+                            onSuccess={() => trackEvent('User', 'logged_in', 'Email')}
                           />
                         </TabsContent>
 
                         <TabsContent value="register" className="space-y-4 mt-6">
                           <RegisterForm
                             siteKey={config.recaptchaSiteKey}
-                            onSuccess={() => trackEvent('User', 'Created an Account', 'Email')}
+                            onSuccess={() => trackEvent('User', 'account_created', 'Email')}
                           />
                         </TabsContent>
                       </Tabs>

--- a/client/src/pages/auth-page.tsx
+++ b/client/src/pages/auth-page.tsx
@@ -137,7 +137,7 @@ export default function AuthPage() {
                     <ForgotPasswordForm
                       siteKey={config.recaptchaSiteKey}
                       onBack={() => setShowForgotPassword(false)}
-                      onRequestSent={() => trackEvent('Auth', 'password_reset_requested', 'Email')}
+                      onRequestSent={() => trackEvent('Auth', 'password_reset_requested')}
                     />
                   ) : (
                     <>
@@ -164,14 +164,14 @@ export default function AuthPage() {
                           <LoginForm
                             siteKey={config.recaptchaSiteKey}
                             onShowForgot={() => setShowForgotPassword(true)}
-                            onSuccess={() => trackEvent('User', 'logged_in', 'Email')}
+                            onSuccess={() => trackEvent('User', 'logged_in')}
                           />
                         </TabsContent>
 
                         <TabsContent value="register" className="space-y-4 mt-6">
                           <RegisterForm
                             siteKey={config.recaptchaSiteKey}
-                            onSuccess={() => trackEvent('User', 'account_created', 'Email')}
+                            onSuccess={() => trackEvent('User', 'account_created')}
                           />
                         </TabsContent>
                       </Tabs>

--- a/client/src/pages/movie-detail.tsx
+++ b/client/src/pages/movie-detail.tsx
@@ -137,9 +137,9 @@ export default function MovieDetail() {
     const label = `${movie.id}:${movie.title}`;
 
     if (wasInWatchlist) {
-      trackEvent('Watchlist', 'Removed', label);
+      trackEvent('Watchlist', 'watchlist_removed', label);
     } else {
-      trackEvent('Watchlist', 'Added', label);
+      trackEvent('Watchlist', 'watchlist_added', label);
     }
 
     toast({

--- a/client/src/pages/report-issue.tsx
+++ b/client/src/pages/report-issue.tsx
@@ -62,7 +62,7 @@ export default function ReportIssue() {
       return await apiRequest('POST', '/api/report-issue', data);
     },
     onSuccess: async () => {
-      trackEvent('Feedback', 'Issue Submitted');
+      trackEvent('Feedback', 'issue_submitted', formData.type);
 
       toast({
         title: 'Issue submitted',

--- a/client/src/pages/report-issue.tsx
+++ b/client/src/pages/report-issue.tsx
@@ -62,7 +62,7 @@ export default function ReportIssue() {
       return await apiRequest('POST', '/api/report-issue', data);
     },
     onSuccess: async () => {
-      trackEvent('Feedback', 'issue_submitted', formData.type);
+      trackEvent('Feedback', 'issue_submitted');
 
       toast({
         title: 'Issue submitted',

--- a/client/src/pages/search.tsx
+++ b/client/src/pages/search.tsx
@@ -43,7 +43,7 @@ export default function Search() {
       const clean = q.trim();
       if (clean.length === 0) return;
 
-      trackEvent('Search', 'Performed', clean);
+      trackEvent('Search', 'search_performed', clean);
     });
   }, [searchQuery, runDebounced]);
 


### PR DESCRIPTION
This pull request standardizes the event names used in the `trackEvent` analytics calls across multiple components and pages. The changes ensure that all event names follow a consistent, snake_case naming convention, which will make analytics tracking and querying more reliable and easier to maintain.

**Analytics event name standardization:**

* Changed all `trackEvent` calls in `movie-card.tsx` and `movie-detail.tsx` to use snake_case event names (`watchlist_added`, `watchlist_removed`) instead of the previous format (`Added`, `Removed`).
* Updated `trackEvent` calls in `auth-page.tsx` for password reset, login, and account creation to use snake_case event names (`password_reset_requested`, `logged_in`, `account_created`).
* Changed the feedback submission event in `report-issue.tsx` to `issue_submitted` for consistency.
* Updated the search event in `search.tsx` to `search_performed` for consistent naming.