### PR TITLE
Add Subgenre Chip Links

### DIFF
--- a/client/src/components/subgenre-chips.tsx
+++ b/client/src/components/subgenre-chips.tsx
@@ -1,0 +1,35 @@
+import { Link } from 'wouter';
+import type { HasSubgenres, SubgenreLite } from '@/lib/subgenres';
+import { getPrimarySubgenre, getSortedSubgenres } from '@/lib/subgenres';
+import { trackEvent } from '@/lib/analytics';
+
+function Chip({ sub }: { sub: SubgenreLite }) {
+  const qs = new URLSearchParams({ subgenre: sub.slug }).toString();
+  const href = `/browse?${qs}`;
+  return (
+    <Link
+      href={href}
+      onClick={() => trackEvent('Navigation', 'subgenre_chip_click', sub.slug)}
+      className="blood-red-bg text-white px-3 py-1 rounded-full text-xs md:text-sm font-medium hover:bg-red-800 focus:outline-none focus:ring-2 focus:ring-red-600"
+      aria-label={`Browse ${sub.name} Titles`}
+    >
+      {sub.name}
+    </Link>
+  );
+}
+
+export default function SubgenreChips({ item }: { item: HasSubgenres }) {
+  const sorted = getSortedSubgenres(item);
+  const fallback = getPrimarySubgenre(item);
+
+  // If no subgenres, show a single primary (if present); otherwise show all sorted.
+  const toRender = sorted.length > 0 ? sorted : fallback ? [fallback] : [];
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {toRender.map((sub) => (
+        <Chip key={sub.id ?? sub.slug} sub={sub} />
+      ))}
+    </div>
+  );
+}

--- a/client/src/lib/subgenres.ts
+++ b/client/src/lib/subgenres.ts
@@ -45,3 +45,8 @@ export function isPrimarySubgenre(s: SubgenreLite, item: HasSubgenres): boolean 
   const first = item.subgenres?.[0];
   return !!first && first.id === s.id;
 }
+
+export function getSortedSubgenres(item: HasSubgenres): SubgenreLite[] {
+  const subs = item.subgenres ?? [];
+  return [...subs].sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
+}

--- a/client/src/pages/movie-detail.tsx
+++ b/client/src/pages/movie-detail.tsx
@@ -10,8 +10,8 @@ import { useWatchlist } from '@/hooks/use-watchlist';
 import { useToast } from '@/hooks/use-toast';
 import Footer from '@/components/footer';
 import { useSearch } from '@/contexts/SearchContext';
+import SubgenreChips from '@/components/subgenre-chips';
 import type { ContentWithPlatforms } from '@shared/schema';
-import { getPrimarySubgenre, getSubgenreNames } from '@/lib/subgenres';
 import { Helmet } from 'react-helmet-async';
 import { trackPageview, trackEvent } from '@/lib/analytics';
 
@@ -117,15 +117,6 @@ export default function MovieDetail() {
       </>
     );
   }
-
-  // Subgenres for chips
-  const subgenreNames = getSubgenreNames(movie);
-  const chipNames =
-    subgenreNames.length > 0
-      ? subgenreNames
-      : getPrimarySubgenre(movie)
-        ? [getPrimarySubgenre(movie)!.name]
-        : [];
 
   const description = movie.description || `Where to watch ${movie.title}.`;
 
@@ -235,16 +226,9 @@ export default function MovieDetail() {
                     )}
                   </div>
 
-                  {/* Subgenres (names) */}
-                  <div className="mt-3 flex flex-wrap gap-2">
-                    {chipNames.map((name, i) => (
-                      <span
-                        key={`${name}-${i}`}
-                        className="blood-red-bg text-white px-3 py-1 rounded-full text-xs font-medium"
-                      >
-                        {name}
-                      </span>
-                    ))}
+                  {/* Subgenres */}
+                  <div className="mt-3">
+                    <SubgenreChips item={movie} />
                   </div>
                 </div>
               </div>
@@ -383,18 +367,9 @@ export default function MovieDetail() {
                   )}
                 </div>
 
-                {/* Subgenres (names only) */}
+                {/* Subgenres */}
                 <div className="mb-4">
-                  <div className="flex flex-wrap gap-2">
-                    {chipNames.map((name, i) => (
-                      <span
-                        key={`${name}-${i}`}
-                        className="inline-block blood-red-bg text-white px-3 py-1 rounded-full text-sm font-medium"
-                      >
-                        {name}
-                      </span>
-                    ))}
-                  </div>
+                  <SubgenreChips item={movie} />
                 </div>
 
                 {/* Streaming Platforms */}


### PR DESCRIPTION
This pull request refactors how subgenres are displayed on the movie detail page by introducing interactive, navigable "chips" for subgenres. It replaces the previous static display of subgenre names with clickable chips that link to a filtered browse page and track user interaction. Additionally, it introduces a utility for sorting subgenres alphabetically.

**Subgenre Display Improvements:**

* Added a new `SubgenreChips` component that renders subgenres as clickable chips, each linking to the browse page filtered by the selected subgenre and tracking clicks for analytics.
* Replaced the previous static subgenre name display in `MovieDetail` with the new `SubgenreChips` component, making the UI more interactive and consistent.

**Subgenre Utility Enhancements:**

* Added a `getSortedSubgenres` utility function to sort subgenres alphabetically by name, ensuring consistent chip ordering.