### PR TITLE
Ensure `null` Critic Rating, User Rating, and Release Date Sort to Bottom

### DIFF
--- a/server/storage/content.ts
+++ b/server/storage/content.ts
@@ -198,18 +198,20 @@ export async function getContent(
   const { field, dir } = parseSort(filters?.sortBy);
 
   if (field === 'release_date') {
-    const nullsLast = sql`${content.year} IS NULL`;
+    const yearNullsLast = sql`${content.year} IS NULL`;
     const byYear = dir === 'asc' ? asc(content.year) : desc(content.year);
-    query = query.orderBy(nullsLast, byYear, asc(content.title));
+    query = query.orderBy(yearNullsLast, byYear, asc(content.title));
   } else if (field === 'critics_rating') {
-    const primary = dir === 'asc' ? asc(content.criticsRating) : desc(content.criticsRating);
-    query = query.orderBy(primary, asc(content.title));
+    const criticsNullsLast = sql`${content.criticsRating} IS NULL`;
+    const byCritics = dir === 'asc' ? asc(content.criticsRating) : desc(content.criticsRating);
+    query = query.orderBy(criticsNullsLast, byCritics, asc(content.title));
   } else if (field === 'users_rating') {
-    const primary = dir === 'asc' ? asc(content.usersRating) : desc(content.usersRating);
-    query = query.orderBy(primary, asc(content.title));
+    const usersNullsLast = sql`${content.usersRating} IS NULL`;
+    const byUsers = dir === 'asc' ? asc(content.usersRating) : desc(content.usersRating);
+    query = query.orderBy(usersNullsLast, byUsers, asc(content.title));
   } else {
-    const primary = dir === 'asc' ? asc(content.averageRating) : desc(content.averageRating);
-    query = query.orderBy(primary, asc(content.title));
+    const byAvg = dir === 'asc' ? asc(content.averageRating) : desc(content.averageRating);
+    query = query.orderBy(byAvg, asc(content.title));
   }
 
   const rows = await query;


### PR DESCRIPTION
This pull request updates the sorting logic in the `getContent` function within `server/storage/content.ts` to ensure that records with null values in key fields are consistently ordered last when sorting by those fields. This improves the reliability and predictability of content sorting, especially when some records have missing data.

Sorting improvements for null values:

* When sorting by `release_date`, `critics_rating`, or `users_rating`, the query now explicitly places records with null values in those fields at the end of the result set by adding a corresponding null-check ordering clause.
* The code for sorting by these fields has been refactored for clarity, using descriptive variable names for null checks and primary sort directions.
* Sorting by `averageRating` remains unchanged, as null handling is not applied for this field.