### PR TITLE
Refactor New to Streaming Page to Show Last Five Releases

### DIFF
--- a/client/src/pages/new-to-streaming.tsx
+++ b/client/src/pages/new-to-streaming.tsx
@@ -1,15 +1,18 @@
 import { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Calendar, Clock } from 'lucide-react';
+import { Clock } from 'lucide-react';
 import Footer from '@/components/footer';
 import MovieCard from '@/components/movie-card';
-import { Content } from '@shared/schema';
+import type { ContentWithPlatforms } from '@shared/schema';
 import { Link, useLocation } from 'wouter';
 import { Button } from '@/components/ui/button';
 import { useSearch } from '@/contexts/SearchContext';
 import { Helmet } from 'react-helmet-async';
 import { trackPageview } from '@/lib/analytics';
+
+type SubgenreLite = { id: number; name: string; slug: string };
+type MovieForCard = ContentWithPlatforms & { primarySubgenre: SubgenreLite | null };
 
 export default function NewToStreaming() {
   const [, setLocation] = useLocation();
@@ -30,7 +33,7 @@ export default function NewToStreaming() {
     data: streamingContent = [],
     isLoading,
     error,
-  } = useQuery<Content[]>({
+  } = useQuery<MovieForCard[]>({
     queryKey: ['/api/new-to-streaming'],
     staleTime: 10 * 60 * 1000, // Cache for 10 minutes
     refetchOnWindowFocus: false,
@@ -109,10 +112,6 @@ export default function NewToStreaming() {
           </p>
           <div className="flex items-center justify-center space-x-6 text-sm text-gray-400 mt-2">
             <div className="flex items-center">
-              <Calendar className="h-4 w-4 mr-2" />
-              Last 30 days
-            </div>
-            <div className="flex items-center">
               <Clock className="h-4 w-4 mr-2" />
               Updated weekly
             </div>
@@ -133,11 +132,11 @@ export default function NewToStreaming() {
             </div>
           ) : (
             <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-6 px-6">
-              {streamingContent.map((content) => (
+              {streamingContent.map((movie) => (
                 <MovieCard
-                  key={content.id}
-                  movie={content}
-                  onClick={() => setLocation(`/title/${content.id}`)}
+                  key={movie.id}
+                  movie={movie}
+                  onClick={() => setLocation(`/title/${movie.id}`)}
                 />
               ))}
             </div>

--- a/server/routes/public/newToStreaming.routes.ts
+++ b/server/routes/public/newToStreaming.routes.ts
@@ -1,32 +1,11 @@
 import type { Express } from 'express';
-import { storage } from '../../storage';
+import { getNewestStreaming } from '@server/storage/content';
 
 export function registerNewToStreamingRoutes(app: Express) {
   app.get('/api/new-to-streaming', async (req, res) => {
     try {
-      console.log('NEW TO STREAMING: Fetching from database by recent release dates');
-
-      // Get content released in the last 30 days, sorted by release date
-      const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
-        .toISOString()
-        .split('T')[0];
-      const allContent = await storage.getContent(
-        { includeHidden: false, includeInactive: false },
-        { includeSubgenres: true, includePrimary: true }
-      );
-
-      const recentReleases = allContent
-        .filter(
-          (content) => content.sourceReleaseDate && content.sourceReleaseDate >= thirtyDaysAgo
-        )
-        .sort(
-          (a, b) =>
-            new Date(b.sourceReleaseDate!).getTime() - new Date(a.sourceReleaseDate!).getTime()
-        )
-        .slice(0, 20);
-
-      console.log(`Found ${recentReleases.length} recent horror releases in database`);
-      res.json(recentReleases);
+      const items = await getNewestStreaming(5);
+      res.json(items);
     } catch (error) {
       console.error('Error fetching new streaming releases:', error);
       res.status(500).json({


### PR DESCRIPTION
This pull request updates the "New to Streaming" feature to improve both backend efficiency and frontend data handling. The backend now provides a more curated, up-to-date list of new streaming content, and the frontend adapts to the updated data structure for better type safety and clarity. The UI also receives a small simplification.

**Backend Improvements:**
* Added a new `getNewestStreaming` function in `server/storage/content.ts` that efficiently queries the database for the latest streaming content, including platform badges and primary subgenre information. The result is limited to a configurable number of items (default 5).
* Updated the API route in `server/routes/public/newToStreaming.routes.ts` to use `getNewestStreaming`, replacing the previous manual filtering and sorting logic. The route now returns a curated set of recent releases instead of all content from the last 30 days.

**Frontend Improvements:**
* Updated the data type in `client/src/pages/new-to-streaming.tsx` to `MovieForCard` (which includes platform and subgenre info) for improved type safety and alignment with the backend response. [[1]](diffhunk://#diff-f0f3831068f1c7023ff6f13d3946dc4fe4f67bd227e327a98be6a1c282b2b3cbL4-R16) [[2]](diffhunk://#diff-f0f3831068f1c7023ff6f13d3946dc4fe4f67bd227e327a98be6a1c282b2b3cbL33-R36)
* Refactored the rendering logic in `client/src/pages/new-to-streaming.tsx` to use the new data structure and variable names, ensuring correct display and navigation.

**UI Simplification:**
* Removed the "Last 30 days" calendar badge from the page header, leaving only the "Updated weekly" indicator for a cleaner look.