### PR TITLE
Rebrand from Scream Stream to FrightByte

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Scream Stream - Top Rated Streaming Horror
+# FrightByte - Top Rated Streaming Horror
 
 Discover the highest-rated horror movies and series currently streaming. Rated by critics and audiences across all major platforms.
 
@@ -15,7 +15,7 @@ brew install postgresql@15
 brew services start postgresql@15
 
 # Create database
-createdb scream_stream_dev
+createdb frightbyte_dev
 ```
 
 ### 2. Setup Project
@@ -23,7 +23,7 @@ createdb scream_stream_dev
 ```bash
 # Clone and install
 git clone <repository-url>
-cd screamstream
+cd frightbyte
 npm install
 
 # Configure environment

--- a/client/index.html
+++ b/client/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
-    <title>Scream Stream - Top Rated Streaming Horror</title>
+    <title>FrightByte - Top Rated Streaming Horror</title>
     <meta
       name="description"
       content="Discover the highest-rated horror movies and series streaming now."

--- a/client/public/robots.txt
+++ b/client/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://screamstream.net/sitemap.xml
+Sitemap: https://frightbyte.net/sitemap.xml

--- a/client/public/sitemap.xml
+++ b/client/public/sitemap.xml
@@ -1,47 +1,47 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://screamstream.net/</loc>
+    <loc>https://frightbyte.net/</loc>
     <lastmod>2025-09-20</lastmod>
   </url>
   <url>
-    <loc>https://screamstream.net/browse</loc>
+    <loc>https://frightbyte.net/browse</loc>
     <lastmod>2025-09-20</lastmod>
   </url>
   <url>
-    <loc>https://screamstream.net/new-to-streaming</loc>
+    <loc>https://frightbyte.net/new-to-streaming</loc>
     <lastmod>2025-09-20</lastmod>
   </url>
   <url>
-    <loc>https://screamstream.net/subgenres</loc>
+    <loc>https://frightbyte.net/subgenres</loc>
     <lastmod>2025-09-20</lastmod>
   </url>
 
-  <url><loc>https://screamstream.net/browse?subgenre=action-horror</loc><lastmod>2025-09-20</lastmod></url>
-  <url><loc>https://screamstream.net/browse?subgenre=anthology</loc><lastmod>2025-09-20</lastmod></url>
-  <url><loc>https://screamstream.net/browse?subgenre=apocalyptic-horror</loc><lastmod>2025-09-20</lastmod></url>
-  <url><loc>https://screamstream.net/browse?subgenre=body-horror</loc><lastmod>2025-09-20</lastmod></url>
-  <url><loc>https://screamstream.net/browse?subgenre=creature-feature</loc><lastmod>2025-09-20</lastmod></url>
-  <url><loc>https://screamstream.net/browse?subgenre=documentary</loc><lastmod>2025-09-20</lastmod></url>
-  <url><loc>https://screamstream.net/browse?subgenre=folk-horror</loc><lastmod>2025-09-20</lastmod></url>
-  <url><loc>https://screamstream.net/browse?subgenre=found-footage</loc><lastmod>2025-09-20</lastmod></url>
-  <url><loc>https://screamstream.net/browse?subgenre=horror-comedy</loc><lastmod>2025-09-20</lastmod></url>
-  <url><loc>https://screamstream.net/browse?subgenre=killer-toys</loc><lastmod>2025-09-20</lastmod></url>
-  <url><loc>https://screamstream.net/browse?subgenre=mystery-horror</loc><lastmod>2025-09-20</lastmod></url>
-  <url><loc>https://screamstream.net/browse?subgenre=post-apocalyptic</loc><lastmod>2025-09-20</lastmod></url>
-  <url><loc>https://screamstream.net/browse?subgenre=psychological-horror</loc><lastmod>2025-09-20</lastmod></url>
-  <url><loc>https://screamstream.net/browse?subgenre=revenge</loc><lastmod>2025-09-20</lastmod></url>
-  <url><loc>https://screamstream.net/browse?subgenre=sci-fi-horror</loc><lastmod>2025-09-20</lastmod></url>
-  <url><loc>https://screamstream.net/browse?subgenre=slasher</loc><lastmod>2025-09-20</lastmod></url>
-  <url><loc>https://screamstream.net/browse?subgenre=splatter-film</loc><lastmod>2025-09-20</lastmod></url>
-  <url><loc>https://screamstream.net/browse?subgenre=supernatural</loc><lastmod>2025-09-20</lastmod></url>
-  <url><loc>https://screamstream.net/browse?subgenre=survival-horror</loc><lastmod>2025-09-20</lastmod></url>
-  <url><loc>https://screamstream.net/browse?subgenre=vampires</loc><lastmod>2025-09-20</lastmod></url>
-  <url><loc>https://screamstream.net/browse?subgenre=werewolves</loc><lastmod>2025-09-20</lastmod></url>
-  <url><loc>https://screamstream.net/browse?subgenre=zombies</loc><lastmod>2025-09-20</lastmod></url>
+  <url><loc>https://frightbyte.net/browse?subgenre=action-horror</loc><lastmod>2025-09-20</lastmod></url>
+  <url><loc>https://frightbyte.net/browse?subgenre=anthology</loc><lastmod>2025-09-20</lastmod></url>
+  <url><loc>https://frightbyte.net/browse?subgenre=apocalyptic-horror</loc><lastmod>2025-09-20</lastmod></url>
+  <url><loc>https://frightbyte.net/browse?subgenre=body-horror</loc><lastmod>2025-09-20</lastmod></url>
+  <url><loc>https://frightbyte.net/browse?subgenre=creature-feature</loc><lastmod>2025-09-20</lastmod></url>
+  <url><loc>https://frightbyte.net/browse?subgenre=documentary</loc><lastmod>2025-09-20</lastmod></url>
+  <url><loc>https://frightbyte.net/browse?subgenre=folk-horror</loc><lastmod>2025-09-20</lastmod></url>
+  <url><loc>https://frightbyte.net/browse?subgenre=found-footage</loc><lastmod>2025-09-20</lastmod></url>
+  <url><loc>https://frightbyte.net/browse?subgenre=horror-comedy</loc><lastmod>2025-09-20</lastmod></url>
+  <url><loc>https://frightbyte.net/browse?subgenre=killer-toys</loc><lastmod>2025-09-20</lastmod></url>
+  <url><loc>https://frightbyte.net/browse?subgenre=mystery-horror</loc><lastmod>2025-09-20</lastmod></url>
+  <url><loc>https://frightbyte.net/browse?subgenre=post-apocalyptic</loc><lastmod>2025-09-20</lastmod></url>
+  <url><loc>https://frightbyte.net/browse?subgenre=psychological-horror</loc><lastmod>2025-09-20</lastmod></url>
+  <url><loc>https://frightbyte.net/browse?subgenre=revenge</loc><lastmod>2025-09-20</lastmod></url>
+  <url><loc>https://frightbyte.net/browse?subgenre=sci-fi-horror</loc><lastmod>2025-09-20</lastmod></url>
+  <url><loc>https://frightbyte.net/browse?subgenre=slasher</loc><lastmod>2025-09-20</lastmod></url>
+  <url><loc>https://frightbyte.net/browse?subgenre=splatter-film</loc><lastmod>2025-09-20</lastmod></url>
+  <url><loc>https://frightbyte.net/browse?subgenre=supernatural</loc><lastmod>2025-09-20</lastmod></url>
+  <url><loc>https://frightbyte.net/browse?subgenre=survival-horror</loc><lastmod>2025-09-20</lastmod></url>
+  <url><loc>https://frightbyte.net/browse?subgenre=vampires</loc><lastmod>2025-09-20</lastmod></url>
+  <url><loc>https://frightbyte.net/browse?subgenre=werewolves</loc><lastmod>2025-09-20</lastmod></url>
+  <url><loc>https://frightbyte.net/browse?subgenre=zombies</loc><lastmod>2025-09-20</lastmod></url>
 
   <url>
-    <loc>https://screamstream.net/report-issue</loc>
+    <loc>https://frightbyte.net/report-issue</loc>
     <lastmod>2025-09-20</lastmod>
   </url>
 </urlset>

--- a/client/src/components/auth/RegisterForm.tsx
+++ b/client/src/components/auth/RegisterForm.tsx
@@ -52,7 +52,7 @@ export default function RegisterForm({ siteKey, onSuccess }: Props) {
 
         toast({
           title: 'Account created!',
-          description: 'Welcome to Scream Stream. Start discovering horror content.',
+          description: 'Welcome to FrightByte. Start discovering horror content.',
         });
         recaptchaRef.current?.reset();
         redirectAfterAuth();

--- a/client/src/components/footer.tsx
+++ b/client/src/components/footer.tsx
@@ -9,7 +9,7 @@ export default function Footer() {
             <div className="flex items-center mb-4">
               <h3 className="text-2xl font-bold blood-red flex items-center">
                 <Skull className="mr-2 h-6 w-6" />
-                Scream Stream
+                FrightByte
               </h3>
             </div>
             <p className="text-gray-400 mb-4">
@@ -64,7 +64,7 @@ export default function Footer() {
 
         <div className="border-t border-gray-800 mt-8 pt-8 text-center">
           <p className="text-gray-400 mb-2">
-            © 2025 Scream Stream. All rights reserved. | Discover the best horror titles streaming
+            © 2025 FrightByte. All rights reserved. | Discover the best horror titles streaming
             online.
           </p>
           <p className="text-gray-500 text-sm">

--- a/client/src/components/header.tsx
+++ b/client/src/components/header.tsx
@@ -87,7 +87,7 @@ export default function Header({ autoFocusSearch }: HeaderProps) {
                       : 'w-auto opacity-100'
                   }`}
                 >
-                  <span className="whitespace-nowrap">Scream Stream</span>
+                  <span className="whitespace-nowrap">FrightByte</span>
                 </span>
               </h1>
             </div>

--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -252,7 +252,7 @@ export default function Admin() {
   return (
     <>
       <Helmet>
-        <title>Admin Portal - Scream Stream</title>
+        <title>Admin Portal - FrightByte</title>
       </Helmet>
 
       <div className="min-h-screen horror-bg">

--- a/client/src/pages/auth-page.tsx
+++ b/client/src/pages/auth-page.tsx
@@ -73,7 +73,7 @@ export default function AuthPage() {
   return (
     <>
       <Helmet>
-        <title>{heading} – Scream Stream</title>
+        <title>{heading} – FrightByte</title>
         <meta name="description" content={subheading} />
       </Helmet>
 
@@ -86,7 +86,7 @@ export default function AuthPage() {
                 <h1 className="text-6xl font-bold text-white mb-6 leading-tight">
                   <div>Welcome to</div>
                   <div>
-                    <span className="blood-red">Scream Stream</span>
+                    <span className="blood-red">FrightByte</span>
                   </div>
                 </h1>
                 <p className="text-xl text-gray-300 mb-8 leading-relaxed">

--- a/client/src/pages/browse.tsx
+++ b/client/src/pages/browse.tsx
@@ -36,8 +36,8 @@ export default function Browse() {
 
   const pageTitle = useMemo(() => {
     return selectedSubgenre !== 'all'
-      ? `Browse ${humanize(selectedSubgenre)} Titles – Scream Stream`
-      : `Browse Streaming Horror – Scream Stream`;
+      ? `Browse ${humanize(selectedSubgenre)} Titles – FrightByte`
+      : `Browse Streaming Horror – FrightByte`;
   }, [selectedSubgenre]);
 
   useEffect(() => {

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -50,7 +50,7 @@ export default function Home() {
   return (
     <>
       <Helmet>
-        <title>Scream Stream - Top Rated Streaming Horror</title>
+        <title>FrightByte - Top Rated Streaming Horror</title>
         <meta
           name="description"
           content="Discover the highest-rated horror movies and series streaming now."

--- a/client/src/pages/movie-detail.tsx
+++ b/client/src/pages/movie-detail.tsx
@@ -50,7 +50,7 @@ export default function MovieDetail() {
     enabled: movieId > 0,
   });
 
-  const pageTitle = movie ? `${movie.title} – Scream Stream` : 'Scream Stream';
+  const pageTitle = movie ? `${movie.title} – FrightByte` : 'FrightByte';
   useEffect(() => {
     if (!movie) return;
     const path = `${window.location.pathname}${window.location.search}`;
@@ -61,7 +61,7 @@ export default function MovieDetail() {
     return (
       <>
         <Helmet>
-          <title>Invalid Title – Scream Stream</title>
+          <title>Invalid Title – FrightByte</title>
           <meta name="robots" content="noindex" />
         </Helmet>
         <div className="min-h-screen horror-bg flex items-center justify-center">
@@ -78,7 +78,7 @@ export default function MovieDetail() {
     return (
       <>
         <Helmet>
-          <title>Loading… – Scream Stream</title>
+          <title>Loading… – FrightByte</title>
           <meta name="robots" content="noindex" />
         </Helmet>
         <div className="min-h-screen horror-bg">
@@ -103,7 +103,7 @@ export default function MovieDetail() {
     return (
       <>
         <Helmet>
-          <title>Title Unavailable – Scream Stream</title>
+          <title>Title Unavailable – FrightByte</title>
           <meta name="robots" content="noindex" />
         </Helmet>
         <div className="min-h-screen horror-bg flex items-center justify-center">

--- a/client/src/pages/new-to-streaming.tsx
+++ b/client/src/pages/new-to-streaming.tsx
@@ -25,7 +25,7 @@ export default function NewToStreaming() {
   // Fire GA pageview when this page is mounted
   useEffect(() => {
     const path = `${window.location.pathname}${window.location.search}`;
-    trackPageview(path, 'New to Streaming – Scream Stream');
+    trackPageview(path, 'New to Streaming – FrightByte');
   }, []);
 
   // Fetch new to streaming content
@@ -43,7 +43,7 @@ export default function NewToStreaming() {
     return (
       <>
         <Helmet>
-          <title>Loading… – Scream Stream</title>
+          <title>Loading… – FrightByte</title>
           <meta name="robots" content="noindex" />
         </Helmet>
         <div className="min-h-screen horror-bg">
@@ -62,7 +62,7 @@ export default function NewToStreaming() {
     return (
       <>
         <Helmet>
-          <title>Error Loading – Scream Stream</title>
+          <title>Error Loading – FrightByte</title>
           <meta name="robots" content="noindex" />
         </Helmet>
         <div className="min-h-screen horror-bg">
@@ -87,12 +87,12 @@ export default function NewToStreaming() {
   return (
     <>
       <Helmet>
-        <title>New to Streaming – Scream Stream</title>
+        <title>New to Streaming – FrightByte</title>
         <meta
           name="description"
           content="Discover the latest horror movies and series that just landed on popular streaming platforms. Fresh scares, updated weekly."
         />
-        <meta property="og:title" content="New to Streaming – Scream Stream" />
+        <meta property="og:title" content="New to Streaming – FrightByte" />
         <meta
           property="og:description"
           content="Discover the latest horror movies and series that just landed on popular streaming platforms."

--- a/client/src/pages/not-found.tsx
+++ b/client/src/pages/not-found.tsx
@@ -7,13 +7,13 @@ import { trackPageview } from '@/lib/analytics';
 export default function NotFound() {
   useEffect(() => {
     const path = `${window.location.pathname}${window.location.search}`;
-    trackPageview(path, '404 Not Found – Scream Stream');
+    trackPageview(path, '404 Not Found – FrightByte');
   }, []);
 
   return (
     <>
       <Helmet>
-        <title>404 Not Found – Scream Stream</title>
+        <title>404 Not Found – FrightByte</title>
         <meta name="description" content="The page you are looking for could not be found." />
         <meta name="robots" content="noindex" />
       </Helmet>

--- a/client/src/pages/profile.tsx
+++ b/client/src/pages/profile.tsx
@@ -35,7 +35,7 @@ export default function Profile() {
   // Profile state
   const [profile, setProfile] = useState({
     name: 'Horror Fan',
-    email: 'fan@screamstream.com',
+    email: 'fan@frightbyte.com',
     bio: 'Love discovering top-ranked streaming horror - from classic Universal monsters to modern psychological thrillers.',
     avatar: '',
     joinDate: 'October 2023',
@@ -62,11 +62,11 @@ export default function Profile() {
 
   // Helmet + GA
   const pageTitle = isAuthenticated
-    ? 'Your Profile – Scream Stream'
-    : 'Profile (Sign In Required) – Scream Stream';
+    ? 'Your Profile – FrightByte'
+    : 'Profile (Sign In Required) – FrightByte';
   const pageDescription = isAuthenticated
-    ? 'View your horror profile, watchlist stats, preferences, and more on Scream Stream.'
-    : 'Sign in to access your profile, watchlist statistics, and preferences on Scream Stream.';
+    ? 'View your horror profile, watchlist stats, preferences, and more on FrightByte.'
+    : 'Sign in to access your profile, watchlist statistics, and preferences on FrightByte.';
 
   useEffect(() => {
     const path = `${window.location.pathname}${window.location.search}`;

--- a/client/src/pages/report-issue.tsx
+++ b/client/src/pages/report-issue.tsx
@@ -36,9 +36,9 @@ export default function ReportIssue() {
     setQuery('');
   }, [setQuery]);
 
-  const pageTitle = 'Report an Issue – Scream Stream';
+  const pageTitle = 'Report an Issue – FrightByte';
   const pageDescription =
-    'Report technical problems, incorrect data, broken links, or suggest content for Scream Stream. Help us improve!';
+    'Report technical problems, incorrect data, broken links, or suggest content for FrightByte. Help us improve!';
 
   useEffect(() => {
     const path = `${window.location.pathname}${window.location.search}`;
@@ -196,7 +196,7 @@ export default function ReportIssue() {
             </h1>
           </div>
           <p className="text-base sm:text-xl text-gray-300 max-w-3xl mx-auto">
-            Help us improve Scream Stream by reporting technical issues, data errors, or suggesting
+            Help us improve FrightByte by reporting technical issues, data errors, or suggesting
             improvements.
           </p>
         </div>

--- a/client/src/pages/search.tsx
+++ b/client/src/pages/search.tsx
@@ -24,17 +24,17 @@ export default function Search() {
 
   const title =
     searchQuery.trim().length === 0
-      ? 'Search Horror Movies & Series – Scream Stream'
-      : `Search Results for "${searchQuery}" – Scream Stream`;
+      ? 'Search Horror Movies & Series – FrightByte'
+      : `Search Results for "${searchQuery}" – FrightByte`;
 
   const description =
     searchQuery.trim().length === 0
-      ? 'Search for streaming horror titles across all platforms. Discover your next scare on Scream Stream.'
-      : `Explore horror movies and series results for "${searchQuery}" on Scream Stream.`;
+      ? 'Search for streaming horror titles across all platforms. Discover your next scare on FrightByte.'
+      : `Explore horror movies and series results for "${searchQuery}" on FrightByte.`;
 
   useEffect(() => {
     const path = `${window.location.pathname}`; // omit query to avoid cardinality
-    trackPageview(path, 'Search – Scream Stream');
+    trackPageview(path, 'Search – FrightByte');
   }, []);
 
   const runDebounced = useDebouncedValue(searchQuery, 700);
@@ -50,7 +50,7 @@ export default function Search() {
   return (
     <>
       <Helmet>
-        <title>Search – Scream Stream</title>
+        <title>Search – FrightByte</title>
         <meta name="description" content={description} />
         <meta property="og:title" content={title} />
         <meta property="og:description" content={description} />

--- a/client/src/pages/subgenres.tsx
+++ b/client/src/pages/subgenres.tsx
@@ -52,7 +52,7 @@ export default function Subgenres() {
 
   useEffect(() => {
     const path = `${window.location.pathname}${window.location.search}`;
-    trackPageview(path, 'Horror Subgenres – Scream Stream');
+    trackPageview(path, 'Horror Subgenres – FrightByte');
   }, []);
 
   const isLoading = moviesLoading || subgenresLoading;
@@ -89,10 +89,10 @@ export default function Subgenres() {
     return (
       <>
         <Helmet>
-          <title>Loading Subgenres – Scream Stream</title>
+          <title>Loading Subgenres – FrightByte</title>
           <meta
             name="description"
-            content="Discover horror subgenres and top-rated titles on Scream Stream."
+            content="Discover horror subgenres and top-rated titles on FrightByte."
           />
         </Helmet>
 
@@ -111,12 +111,12 @@ export default function Subgenres() {
   return (
     <>
       <Helmet>
-        <title>Horror Subgenres – Scream Stream</title>
+        <title>Horror Subgenres – FrightByte</title>
         <meta
           name="description"
-          content="From supernatural scares to psychological thrillers, explore horror subgenres and find your next fright on Scream Stream."
+          content="From supernatural scares to psychological thrillers, explore horror subgenres and find your next fright on FrightByte."
         />
-        <meta property="og:title" content="Horror Subgenres – Scream Stream" />
+        <meta property="og:title" content="Horror Subgenres – FrightByte" />
         <meta
           property="og:description"
           content="Explore horror subgenres including supernatural, psychological, slasher, and more. Discover what makes each uniquely terrifying."

--- a/client/src/pages/watchlist.tsx
+++ b/client/src/pages/watchlist.tsx
@@ -23,17 +23,17 @@ export default function Watchlist() {
 
   useEffect(() => {
     const path = `${window.location.pathname}${window.location.search}`;
-    trackPageview(path, 'My Watchlist – Scream Stream');
+    trackPageview(path, 'My Watchlist – FrightByte');
   }, []);
 
   if (isWatchlistLoading) {
     return (
       <>
         <Helmet>
-          <title>My Watchlist – Scream Stream</title>
+          <title>My Watchlist – FrightByte</title>
           <meta
             name="description"
-            content="Your personal collection of upcoming scares on Scream Stream."
+            content="Your personal collection of upcoming scares on FrightByte."
           />
         </Helmet>
 
@@ -52,10 +52,10 @@ export default function Watchlist() {
   return (
     <>
       <Helmet>
-        <title>My Watchlist – Scream Stream</title>
+        <title>My Watchlist – FrightByte</title>
         <meta
           name="description"
-          content="Save your favorite horror movies and series to your personal watchlist. Keep track of upcoming scares on Scream Stream."
+          content="Save your favorite horror movies and series to your personal watchlist. Keep track of upcoming scares on FrightByte."
         />
       </Helmet>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "screamstream",
+  "name": "frightbyte",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "screamstream",
+      "name": "frightbyte",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "screamstream",
+  "name": "frightbyte",
   "version": "1.0.0",
   "type": "module",
   "license": "MIT",

--- a/server/email.ts
+++ b/server/email.ts
@@ -17,8 +17,8 @@ interface EmailParams {
 export async function sendEmail(params: EmailParams): Promise<boolean> {
   try {
     const sender = {
-      email: 'help@screamstream.net',
-      name: 'Scream Stream',
+      email: 'help@frightbyte.net',
+      name: 'FrightByte',
     };
 
     await client.send({
@@ -38,7 +38,7 @@ export async function sendEmail(params: EmailParams): Promise<boolean> {
 
 export function generatePasswordResetEmail(resetUrl: string): { text: string } {
   const text = `
-You've requested to reset your password for Scream Stream.
+You've requested to reset your password for FrightByte.
 
 Click the link below to reset your password:
 ${resetUrl}
@@ -48,7 +48,7 @@ If you didn't request this password reset, please ignore this email.
 This link will expire in 1 hour for security purposes.
 
 Best regards,
-The Scream Stream Team
+The FrightByte Team
   `;
 
   return { text };

--- a/server/routes/auth/password.routes.ts
+++ b/server/routes/auth/password.routes.ts
@@ -43,7 +43,7 @@ export function registerPasswordRoutes(app: Express) {
 
       const emailSent = await sendEmail({
         to: email,
-        subject: 'Password Reset - Scream Stream',
+        subject: 'Password Reset - FrightByte',
         text: emailContent.text,
       });
 


### PR DESCRIPTION
This pull request rebrands the application from "Scream Stream" to "FrightByte" across all user-facing content, metadata, and configuration files. The changes ensure that the new name, "FrightByte", appears consistently throughout the codebase, including UI components, SEO metadata, sitemap, and documentation.

**Rebranding and Naming Updates:**

* Updated all titles, headings, and visible text in UI components to use "FrightByte" instead of "Scream Stream" (e.g., headers, footers, profile, registration, and various pages).

**Documentation and Configuration:**

* Changed the project name and references in `README.md` and setup instructions to "FrightByte".
* Updated all URLs, email addresses, and references in `sitemap.xml`, `robots.txt`, and profile defaults to use the new domain and branding.